### PR TITLE
Inverse filters should be immutable

### DIFF
--- a/src/FormalIdSyntax/Components/Filter.php
+++ b/src/FormalIdSyntax/Components/Filter.php
@@ -16,7 +16,10 @@ final class Filter implements Stringable
     /** @var list<Character|array{0: Character, 1: Character}> */
     private array $set = [];
 
-    private bool $inverse = false;
+    public function __construct(
+        private readonly bool $inverse = false
+    ) {
+    }
 
     public function __toString(): string
     {
@@ -54,10 +57,17 @@ final class Filter implements Stringable
         return $this;
     }
 
-    public function inverse(): self
+    public function getInverse(): self
     {
-        $this->inverse = true;
+        $newInstance = new self($this->inverse === false);
+        foreach ($this->set as $rangeOrChar) {
+            if (is_array($rangeOrChar)) {
+                $newInstance->addRange($rangeOrChar[0], $rangeOrChar[1]);
+            } else {
+                $newInstance->addChar($rangeOrChar);
+            }
+        }
 
-        return $this;
+        return $newInstance;
     }
 }

--- a/src/TransliteratorBuilder.php
+++ b/src/TransliteratorBuilder.php
@@ -135,7 +135,7 @@ class TransliteratorBuilder
 
     public function keep(Filter $filter): static
     {
-        return $this->addSingleID(new SingleID(new BasicID(SpecialTag::Remove), $filter->inverse()));
+        return $this->addSingleID(new SingleID(new BasicID(SpecialTag::Remove), $filter->getInverse()));
     }
 
     /**

--- a/tests/Unit/FormalIdSyntax/Components/FilterTest.php
+++ b/tests/Unit/FormalIdSyntax/Components/FilterTest.php
@@ -30,20 +30,34 @@ class FilterTest extends TestCase
         static::assertSame('[a-zA-Z]', (new Filter())->addRange(new Character('a'), new Character('z'))->addRange(new Character('A'), new Character('Z'))->__toString());
     }
 
-    /**
-     * @covers ::inverse
-     * @covers ::__toString
-     */
+    /** @covers ::__toString */
     public function testInverse(): void
     {
-        static::assertSame('[^a]', (new Filter())->addChar(new Character('a'))->inverse()->__toString());
-        static::assertSame('[^a-z]', (new Filter())->addRange(new Character('a'), new Character('z'))->inverse()->__toString());
+        static::assertSame('[^a]', (new Filter(true))->addChar(new Character('a'))->__toString());
+        static::assertSame('[^a-z]', (new Filter(true))->addRange(new Character('a'), new Character('z'))->__toString());
     }
 
     /** @covers ::__toString */
     public function testToStringOnEmptyFilter(): void
     {
         static::assertSame('', (new Filter())->__toString());
-        static::assertSame('', (new Filter())->inverse()->__toString());
+        static::assertSame('', (new Filter(true))->__toString());
+    }
+
+    /** @covers ::getInverse */
+    public function testGetInverse(): void
+    {
+        static::assertEquals(new Filter(true), (new Filter())->getInverse());
+        static::assertEquals(new Filter(true), (new Filter(false))->getInverse());
+        static::assertEquals(new Filter(false), (new Filter(true))->getInverse());
+
+        static::assertEquals(new Filter(), (new Filter())->getInverse()->getInverse());
+        static::assertEquals(new Filter(false), (new Filter(false))->getInverse()->getInverse());
+        static::assertEquals(new Filter(true), (new Filter(true))->getInverse()->getInverse());
+
+        static::assertEquals(
+            (new Filter())->addChar(new Character('a'))->addRange(new Character('A'), new Character('Z')),
+            (new Filter())->addChar(new Character('a'))->addRange(new Character('A'), new Character('Z'))->getInverse()->getInverse(),
+        );
     }
 }

--- a/tests/Unit/TransliteratorBuilderTest.php
+++ b/tests/Unit/TransliteratorBuilderTest.php
@@ -307,6 +307,38 @@ class TransliteratorBuilderTest extends TestCase
     }
 
     /**
+     * @covers ::remove
+     * @covers ::getConversions
+     */
+    public function testRemove(): void
+    {
+        static::assertEquals(
+            [
+                new SingleID(new BasicID(SpecialTag::Remove), (new Filter())->addChar(new Character('a')))
+            ],
+            (new TransliteratorBuilder())
+                ->remove((new Filter())->addChar(new Character('a')))
+                ->getConversions()
+        );
+    }
+
+    /**
+     * @covers ::keep
+     * @covers ::getConversions
+     */
+    public function testKeep(): void
+    {
+        static::assertEquals(
+            [
+                new SingleID(new BasicID(SpecialTag::Remove), (new Filter())->addChar(new Character('a')))
+            ],
+            (new TransliteratorBuilder())
+                ->keep((new Filter(true))->addChar(new Character('a')))
+                ->getConversions()
+        );
+    }
+
+    /**
      * @covers ::replace
      * @covers ::getConversions
      */


### PR DESCRIPTION
When creating a filter A and supplying it to method B, if it gets inverted in method C it will also be inverted in method B. This should not be the case, and the property $inverse should be immutable instead.